### PR TITLE
Adding support for loadbalancer-ips

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,12 @@ options:
     type: int
     default: 600
     description: Timeout in seconds for reading a response from proxy server.
+  loadbalancer-ips:
+    type: string
+    description: |
+      Space seperated list of IP addresses of loadbalancers in front of control plane.
+      A common case for this is virtual IP addresses that are floated in front of the
+      kubeapi-load-balancer charm. The workers will alternate IP addresses from this
+      list to distribute load. If you have 2 IPs and 4 workers, each IP will be used
+      by 2 workers.
+    default: ""


### PR DESCRIPTION
config option for specifying the load balancer IP to pass to the worker nodes. Allows for floating a virtual IP in front of the load balancers.

This is the load balancer side of https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/5

The user would set this config on the master if not using a load balancer and on the load balancer if using one. At first, I thought this was redundant on the load balancer charm, but then I thought about the high availability use case and just wanting to have multiple load balancers and float a virtual IP in front of them through some other means.