### PR TITLE
Enable IPv6 / dual-stack

### DIFF
--- a/templates/apilb.conf
+++ b/templates/apilb.conf
@@ -9,6 +9,7 @@ upstream target_service {
 
 server {
     listen {{ port }} ssl http2;
+    listen [::]:{{ port }} ssl http2 ipv6only=on;
     server_name {{ server_name }};
 
     access_log /var/log/nginx.access.log;


### PR DESCRIPTION
Changes the nginx config to listen on IPv6 if available, and includes the IPv6 address in the cert.

Fixes [lp:1857173](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1857173)