### PR TITLE
update nginx template to fix kubectl exec

### DIFF
--- a/templates/apilb.conf
+++ b/templates/apilb.conf
@@ -23,6 +23,7 @@ server {
 
     location / {
       proxy_buffering         off;
+      proxy_http_version      1.1;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
`kubectl exec` fails in 1.24 when requests go through the `kubeapi-load-balancer` -- the `Upgrade` header is [only useful](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade) in http/1.1, so make sure we're using that in our template.

Fixes: https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1940527