### PR TITLE
allow non-leader units to read all_requests data, but not write responses

### DIFF
--- a/reactive/load_balancer.py
+++ b/reactive/load_balancer.py
@@ -150,6 +150,7 @@ def maybe_write_apilb_logrotate_config():
 def allow_lb_consumers_to_read_requests():
     lb_consumers = endpoint_from_name("lb-consumers")
     lb_consumers.follower_perms(read=True)
+    return lb_consumers
 
 
 @when("nginx.available", "tls_client.certs.saved")
@@ -158,7 +159,7 @@ def allow_lb_consumers_to_read_requests():
 def install_load_balancer():
     """Create the default vhost template for load balancing"""
     apiserver = endpoint_from_name("apiserver")
-    lb_consumers = endpoint_from_name("lb-consumers")
+    lb_consumers = allow_lb_consumers_to_read_requests()
 
     if not (server_crt_path.exists() and server_key_path.exists()):
         hookenv.log("Skipping due to missing cert")
@@ -213,7 +214,6 @@ def upgrade_charm():
     if is_state("certificates.available") and is_state("website.available"):
         request_server_certificates()
     maybe_write_apilb_logrotate_config()
-    allow_lb_consumers_to_read_requests()
 
 
 @hook("pre-series-upgrade")

--- a/reactive/load_balancer.py
+++ b/reactive/load_balancer.py
@@ -147,6 +147,11 @@ def maybe_write_apilb_logrotate_config():
             fp.write(apilb_nginx)
 
 
+def allow_lb_consumers_to_read_requests():
+    lb_consumers = endpoint_from_name("lb-consumers")
+    lb_consumers.follower_perms(read=True)
+
+
 @when("nginx.available", "tls_client.certs.saved")
 @when_any("endpoint.lb-consumers.joined", "apiserver.available")
 @when_not("upgrade.series.in-progress")
@@ -208,6 +213,7 @@ def upgrade_charm():
     if is_state("certificates.available") and is_state("website.available"):
         request_server_certificates()
     maybe_write_apilb_logrotate_config()
+    allow_lb_consumers_to_read_requests()
 
 
 @hook("pre-series-upgrade")


### PR DESCRIPTION
[LP#2017814](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/2017814)

When this charm is scaled-out, only the leader unit has access to the request data over the lb_consumers interface to create a response. It is however necessary to expose the request data to the follower charms, so they can configure their units according to the requests.

Depends on:
* https://github.com/juju-solutions/loadbalancer-interface/pull/16 to be merged and published to pypi
