### PR TITLE
Ensure 1.26-ck4 tests on juju 2.9 and jammy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
-          juju-channel: 3.1/stable
+          juju-channel: 2.9/stable
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
       - name: Run test

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     pytest
     pytest-operator
     ipdb
+    juju < 3.1
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:format]


### PR DESCRIPTION
Backporting bug fixes for the following launchpad issues for 1.26+ck4
* LP#2017814 [nginx configuration is missing on non-leader units when VIP is set](https://launchpad.net/bugs/2017814)
* LP#2017812 [ha-cluster-vip not correctly written to kubeconfig](https://launchpad.net/bugs/2004612)