### PR TITLE
Fix LoadBalancer addresses

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -227,7 +227,7 @@ class CharmKubeApiLoadBalancer(ops.CharmBase):
         """Provide load balancer addresses to the requests based on their protocol and address type."""
         lb_addresses = self._get_lb_addresses()
 
-        for request in self.load_balancer.all_requests:
+        for request in self.load_balancer.new_requests:
             response = request.response
             if request.protocol not in (
                 request.protocols.tcp,
@@ -244,7 +244,7 @@ class CharmKubeApiLoadBalancer(ops.CharmBase):
             else:
                 network: Binding = self.model.get_binding("lb-consumers")
                 private_address = network.network.bind_address
-                public_address = network.network.ingress_address
+                public_address = self._get_public_address()
             if request.public:
                 response.address = public_address
             else:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -227,7 +227,7 @@ class TestCharm(unittest.TestCase):
             mock_lb_addresses = ["10.1.1.1", "10.1.1.2"]
             mock_event = MagicMock()
             mock_get_lb_addresses.return_value = mock_lb_addresses
-            mock_load_balancer.all_requests = [mock_request]
+            mock_load_balancer.new_requests = [mock_request]
 
             self.charm._provide_lbs(mock_event)
 
@@ -241,7 +241,7 @@ class TestCharm(unittest.TestCase):
             mock_event = MagicMock()
             mock_request.protocol = "unsupported"
             mock_lb_addresses = ["10.1.1.1", "10.1.1.2"]
-            mock_load_balancer.all_requests = [mock_request]
+            mock_load_balancer.new_requests = [mock_request]
             mock_get_lb_addresses.return_value = mock_lb_addresses
 
             self.charm._provide_lbs(mock_event)
@@ -259,7 +259,7 @@ class TestCharm(unittest.TestCase):
         ) as mock_binding:
             mock_request = MagicMock()
             mock_request.protocol = "tcp"
-            mock_load_balancer.all_requests = [mock_request]
+            mock_load_balancer.new_requests = [mock_request]
             mock_get_lb_addresses.return_value = []
             mock_network = MagicMock()
             mock_network.network.bind_address = "10.1.1.3"
@@ -276,7 +276,7 @@ class TestCharm(unittest.TestCase):
         with patch.object(self.charm, "load_balancer") as mock_load_balancer:
             mock_request = MagicMock()
             mock_request.protocol = "tcp"
-            mock_load_balancer.all_requests = [mock_request]
+            mock_load_balancer.new_requests = [mock_request]
             mock_get_lb_addresses.return_value = []
             mock_lb_addresses = ["10.1.1.1", "10.1.1.2"]
             mock_get_lb_addresses.return_value = mock_lb_addresses


### PR DESCRIPTION
## Summary
This pull request addresses the issue with the values of the LoadBalancer addresses that are returned to the requester.

## Changes
- Updated to use `new_requests` in order to respond only to unhandled requests.
- Replaced `ingress_address` with `public_address`.
- Made adjustments to unit tests for compatibility.