### PR TITLE
Install `nginx-prometheus-exporter`  and export metrics over `cos`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+nginx-prometheus-exporter_linux_*.tar.gz
+sha256sums.txt

--- a/build-resources.sh
+++ b/build-resources.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eux
+
+VERSION="0.11.0"
+
+
+# This script will generate nginx-prometheus-exporter
+function fetch() {
+  # fetch a binary and make sure it's what we expect (executable > 3MB)
+  location="${1-}"
+
+  # remove everything up until the last slash to get the filename
+  filename=$(echo "${location##*/}")
+  fetch_cmd="wget ${location} -O ./${filename}"
+  ${fetch_cmd}
+  echo $filename
+}
+
+function fetch_and_validate() {
+  local filename=$(fetch "${1-}")
+  local sha_file="${2}"
+  local arch="${3}"
+  local sum=$(sha256sum $filename)
+  grep -Fxq "${sum}" "${2}"
+  mv nginx-prometheus-exporter{_${VERSION},}_linux_${arch}.tar.gz
+}
+
+fetch https://github.com/nginxinc/nginx-prometheus-exporter/releases/download/v${VERSION}/sha256sums.txt
+ARCH=${ARCH:-"amd64 arm64 s390x"}
+for arch in ${ARCH}; do
+  fetch_and_validate \
+    https://github.com/nginxinc/nginx-prometheus-exporter/releases/download/v${VERSION}/nginx-prometheus-exporter_${VERSION}_linux_${arch}.tar.gz \
+    ${PWD}/sha256sums.txt \
+    $arch
+done

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,10 +10,32 @@ bases:
     run-on:
     - name: ubuntu
       channel: "20.04"
-      architectures: ["amd64", "arm64", "s390x"]
+      architectures: ["amd64"]
     - name: ubuntu
       channel: "22.04"
-      architectures: ["amd64", "arm64", "s390x"]
+      architectures: ["amd64"]
+  - build-on:
+    - name: ubuntu
+      channel: "20.04"
+      architectures: ["arm64"]
+    run-on:
+    - name: ubuntu
+      channel: "20.04"
+      architectures: ["arm64"]
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
+  - build-on:
+    - name: ubuntu
+      channel: "20.04"
+      architectures: ["s390x"]
+    run-on:
+    - name: ubuntu
+      channel: "20.04"
+      architectures: ["s390x"]
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["s390x"]
 parts:
   charm:
     build-packages: [git]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,6 +13,14 @@ subordinate: false
 series:
   - jammy
   - focal
+resources:
+  nginx-prometheus-exporter:
+    type: file
+    filename: nginx-prometheus-exporter.tar.gz
+    description: |-
+      Binary Release of the nginx prometheus exporter
+      https://github.com/nginxinc/nginx-prometheus-exporter/releases
+
 requires:
   apiserver:
     interface: http

--- a/src/prometheus_alert_rules/nginx_rule.yaml
+++ b/src/prometheus_alert_rules/nginx_rule.yaml
@@ -1,12 +1,21 @@
 groups:
-  - name: nginx_service_health
+  - name: nginx_endpoint_health
     rules:
-      - alert: NginxServiceUnhealthy
-        expr: node_systemd_unit_state{name="nginx.service",state="active",type="forking"} != 1
-        for: 1m
+      - alert: NginxEndpointUnhealthy
+        expr: nginx_up{juju_charm!=".*"} != 1
+        for: 0m
         labels:
           severity: critical
         annotations:
-          summary: "Nginx service is unhealthy"
-          description: "The Nginx service unit is not in the expected healthy state."
-
+          summary: Nginx endpoint is unhealthy (instance {{ $labels.instance }})
+          description: The Nginx endpoint is not in the expected healthy state.
+  - name: prometheus_target_missing
+    rules:
+    - alert: PrometheusTargetMissing
+      expr: up{juju_charm!=".*"} == 0
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Prometheus target missing (instance {{ $labels.instance }})
+        description: "Nginx exporter target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/templates/metrics.conf
+++ b/templates/metrics.conf
@@ -1,0 +1,11 @@
+server {
+    listen 8080;
+    # Optionally: allow access only from localhost
+    listen 127.0.0.1:8080;
+
+    server_name _;
+
+    location /status {
+        stub_status;
+    }
+}

--- a/templates/nginx-prometheus-exporter.service
+++ b/templates/nginx-prometheus-exporter.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Nginx Prometheus Exporter
+Wants=network-online.target
+After=network-online.target
+
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=5s
+
+ExecStart=/opt/nginx-prometheus-exporter/nginx-prometheus-exporter \
+    -nginx.scrape-uri="http://localhost:8080/status"\
+    -web.listen-address=":9113"
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -4,6 +4,8 @@ applications:
     charm: {{charm}}
     num_units: 1
     expose: true
+    resources:
+      nginx-prometheus-exporter: {{resource_path}}/nginx-prometheus-exporter_linux_{{arch}}.tar.gz
 relations:
 - [kubeapi-load-balancer:lb-consumers, kubernetes-control-plane:loadbalancer-internal]
 - [kubeapi-load-balancer:lb-consumers, kubernetes-control-plane:loadbalancer-external]

--- a/tests/integration/test_kubeapi-load-balancer_integration.py
+++ b/tests/integration/test_kubeapi-load-balancer_integration.py
@@ -23,11 +23,24 @@ async def test_build_and_deploy(ops_test):
         log.info("Build Charm...")
         charm = await ops_test.build_charm(".")
 
+    resource_path = ops_test.tmp_path / "charm-resources"
+    resource_path.mkdir()
+    resource_build_script = Path("./build-resources.sh").resolve()
+    log.info("Building charm resources")
+    retcode, stdout, stderr = await ops_test.run(str(resource_build_script), cwd=resource_path)
+    if retcode != 0:
+        log.error(f"retcode: {retcode}")
+        log.error(f"stdout:\n{stdout.strip()}")
+        log.error(f"stderr:\n{stderr.strip()}")
+        pytest.fail("Failed to build charm resources")
+
     log.info("Build Bundle...")
     bundle, *overlays = await ops_test.async_render_bundles(
         ops_test.Bundle("kubernetes-core", channel="edge"),
         Path("tests/data/charm.yaml"),
+        arch="amd64",
         charm=charm,
+        resource_path=resource_path,
     )
 
     log.info("Deploying bundle")
@@ -59,3 +72,16 @@ async def test_load_balancer_forced_address(ops_test):
     finally:
         await api_lb.reset_config(["loadbalancer-ips"])
         await ops_test.model.wait_for_idle(status="active", timeout=10 * 60)
+
+
+async def test_load_balancer_metrics(ops_test):
+    """Validate that the node metrics are available."""
+    api_lb = ops_test.model.applications["kubeapi-load-balancer"]
+
+    action = await api_lb.units[0].run("curl http://localhost:8080/status")
+    result = await action.wait()
+    assert "Active connections: " in result.results["stdout"], "Nginx Status stub unavailable"
+
+    action = await api_lb.units[0].run("curl http://localhost:9113/metrics")
+    result = await action.wait()
+    assert "nginx_up 1" in result.results["stdout"], "Prometheus exporter unavailable"

--- a/tests/integration/test_kubeapi-load-balancer_integration.py
+++ b/tests/integration/test_kubeapi-load-balancer_integration.py
@@ -39,7 +39,7 @@ async def test_build_and_deploy(ops_test):
         ops_test.Bundle("kubernetes-core", channel="edge"),
         Path("tests/data/charm.yaml"),
         arch="amd64",
-        charm=charm,
+        charm=charm.resolve(),
         resource_path=resource_path,
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -215,7 +215,7 @@ class TestCharm(unittest.TestCase):
         mock_service_stop,
         mock_path,
     ):
-        with (patch.object(self.charm.model.resources, "fetch") as mock_fetch,):
+        with patch.object(self.charm.model.resources, "fetch") as mock_fetch:
             mock_resource = mock_fetch.return_value
             mock_resource.stat().st_size = 3000000
             self.charm._install_exporter()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -51,14 +51,20 @@ class TestCharm(unittest.TestCase):
             servers = {80: {("backend1", 8080), ("backend2", 8081)}}
             self.harness.update_config({"proxy_read_timeout": 10})
             self.charm._configure_nginx(servers)
-            self.mock_nginx.return_value.configure_site.assert_called_once_with(
-                "apilb",
-                Path.cwd() / "templates" / "apilb.conf",
-                servers=servers,
-                server_certificate="/srv/kubernetes/server.crt",
-                server_key="/srv/kubernetes/server.key",
-                proxy_read_timeout=10,
-            )
+            assert self.mock_nginx.return_value.configure_site.mock_calls == [
+                call(
+                    "apilb",
+                    Path.cwd() / "templates" / "apilb.conf",
+                    servers=servers,
+                    server_certificate="/srv/kubernetes/server.crt",
+                    server_key="/srv/kubernetes/server.key",
+                    proxy_read_timeout=10,
+                ),
+                call(
+                    "metrics",
+                    Path.cwd() / "templates" / "metrics.conf",
+                ),
+            ]
             self.mock_nginx.return_value.remove_default_site.assert_called_once()
             mock_write.assert_called_once()
 
@@ -196,9 +202,39 @@ class TestCharm(unittest.TestCase):
             mock_open.assert_called_once_with(protocol="tcp", port=8081)
             mock_close.assert_called_once_with(protocol="tcp", port=8080)
 
+    @patch("charm.Path")
+    @patch("charm.tarfile", MagicMock())
+    @patch("charm.service_running", MagicMock(return_value=True))
+    @patch("charm.service_stop")
+    @patch("charm.daemon_reload")
+    @patch("charm.service_restart")
+    def test_install_exporter(
+        self,
+        mock_service_restart,
+        mock_daemon_reload,
+        mock_service_stop,
+        mock_path,
+    ):
+        with (patch.object(self.charm.model.resources, "fetch") as mock_fetch,):
+            mock_resource = mock_fetch.return_value
+            mock_resource.stat().st_size = 3000000
+            self.charm._install_exporter()
+
+            assert mock_path.mock_calls == [
+                call("/opt", "nginx-prometheus-exporter"),
+                call().mkdir(parents=True, exist_ok=True),
+                call("/etc/systemd/system/nginx-prometheus-exporter.service"),
+                call().exists(),
+                call().exists().__bool__(),
+            ]
+            mock_service_stop.assert_called_once_with("nginx-prometheus-exporter")
+            mock_daemon_reload.assert_called_once_with()
+            mock_service_restart.assert_called_once_with("nginx-prometheus-exporter")
+
     @patch("charm.CharmKubeApiLoadBalancer._request_server_certificates")
     @patch("charm.CharmKubeApiLoadBalancer._write_certificates")
     @patch("charm.CharmKubeApiLoadBalancer._install_load_balancer")
+    @patch("charm.CharmKubeApiLoadBalancer._install_exporter")
     @patch("charm.CharmKubeApiLoadBalancer._configure_hacluster")
     @patch("charm.CharmKubeApiLoadBalancer._set_nginx_version")
     def test_reconcile(
@@ -206,6 +242,7 @@ class TestCharm(unittest.TestCase):
         mock_set_nginx_version,
         mock_configure_hacluster,
         mock_install_load_balancer,
+        mock_install_exporter,
         mock_write_certificates,
         mock_request_server_certificates,
     ):
@@ -215,6 +252,7 @@ class TestCharm(unittest.TestCase):
         mock_request_server_certificates.assert_called_once()
         mock_write_certificates.assert_called_once()
         mock_install_load_balancer.assert_called_once()
+        mock_install_exporter.assert_called_once()
         mock_configure_hacluster.assert_called_once()
         mock_set_nginx_version.assert_called_once()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -220,11 +220,10 @@ class TestCharm(unittest.TestCase):
             mock_resource.stat().st_size = 3000000
             self.charm._install_exporter()
 
-            assert mock_path.mock_calls == [
+            mock_path.assert_has_calls == [
                 call("/opt", "nginx-prometheus-exporter"),
                 call().mkdir(parents=True, exist_ok=True),
                 call("/etc/systemd/system/nginx-prometheus-exporter.service"),
-                call().exists(),
                 call().exists().__bool__(),
             ]
             mock_service_stop.assert_called_once_with("nginx-prometheus-exporter")


### PR DESCRIPTION
* will first require https://github.com/charmed-kubernetes/jenkins/pull/1416 to build charms

Expose nginx metrics (which implements the load-balancer) over the cos relation by mapping the nginx status stub through the `nginx-prometheus-exporter`

These changes add that exporter binary as a charm resource which is an arch specific binary.