### PR TITLE
Add `ConfigurationContext` class

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,8 @@ options:
     type: string
     default: ""
     description: |
-      This option allows the juju operator to configure directives inside the nginx events context in /etc/nginx/nginx.conf. Provide a valid block of YAML. For instance:
+      This option allows the juju operator to configure directives inside the nginx events
+      context in /etc/nginx/nginx.conf. Provide a valid block of YAML. For instance:
 
       ```yaml
         worker_connections: 512
@@ -36,7 +37,8 @@ options:
     type: string
     default: ""
     description: |
-      This option allows the juju operator to configure directives in the main context block of /etc/nginx/nginx.conf. Provide a valid block of YAML. For instance:
+      This option allows the juju operator to configure directives in the main context block
+      of /etc/nginx/nginx.conf. Provide a valid block of YAML. For instance:
 
       ```yaml
         worker_rlimit_nofile: 1024
@@ -44,6 +46,21 @@ options:
       ```
 
       The directives specified here have a broad impact on the entire NGINX configuration. For
+      detailed information about these directives, refer to the upstream documentation:
+        https://nginx.org/en/docs/
+  nginx-http-config:
+    type: string
+    default: ""
+    description: |
+      This option allows the juju operator to configure directives in the http context block
+      of /etc/nginx/nginx.conf. Provide a valid block of YAML. For instance:
+
+      ```yaml
+        worker_rlimit_nofile: 1024
+        worker_processes: "auto"
+      ```
+
+      The directives specified here modify how Nginx handles HTTP or HTTPS connections. For
       detailed information about these directives, refer to the upstream documentation:
         https://nginx.org/en/docs/
   ha-cluster-dns:

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,16 +113,17 @@ class CharmKubeApiLoadBalancer(ops.CharmBase):
         in the configuration, removes the default NGINX site, and writes the NGINX log
         rotation configuration.
         """
-        context = {}
+        contexts = {}
         try:
-            context["main"] = yaml.safe_load(self.config.get("nginx-main-config"))
-            context["events"] = yaml.safe_load(self.config.get("nginx-events-config"))
+            contexts["main"] = yaml.safe_load(self.config.get("nginx-main-config")) or {}
+            contexts["events"] = yaml.safe_load(self.config.get("nginx-events-config")) or {}
+            contexts["http"] = yaml.safe_load(self.config.get("nginx-http-config")) or {}
         except YAMLError:
             log.exception("Encountered juju config parsing error")
             status.add(BlockedStatus("Failed to configure NGINX context. Check config values."))
             return
         try:
-            self.nginx.configure_daemon(context)
+            self.nginx.configure_daemon(contexts)
             self.nginx.remove_default_site()
             self._write_nginx_logrotate_config()
         except subprocess.CalledProcessError:

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,75 +1,31 @@
-{%- set main = main or {} %}
-{%- set events = events or {} %}
-user www-data;
-pid /run/nginx.pid;
-include /etc/nginx/modules-enabled/*.conf;
-worker_processes {{ main.get('worker_processes') | default('auto', true)}};
-{%- for key, value in main.items() %}
+{%- macro render_context(context, indent="") -%}
+{{ indent }}# Defaults
+{%- for key, value in context.defaults.items() %}
 {%- if value is not none %}
-{{ key }} {{ value }};
+{{ indent }}{{ key }} {{ value }};
 {%- endif %}
 {%- endfor %}
+{{ indent }}# Extra Config
+{%- for key, value in context.extra.items() %}
+{%- if value is not none %}
+{{ indent }}{{ key }} {{ value }};
+{%- endif %}
+{%- endfor %}
+{%- endmacro %}
+include /etc/nginx/modules-enabled/*.conf;
+{{ render_context(main) }}
+
 
 events {
-  worker_connections {{ events.get('worker_connections') | default('768', true) }};
-  {%- for key, value in events.items() %}
-  {%- if value is not none %}
-  {{ key }} {{ value }};
-  {%- endif %}
-  {%- endfor %}
+{{ render_context(events, "  ") }}
 }
 
 http {
+{{ render_context(http, "  ") }}
 
-	##
-	# Basic Settings
-	##
-
-	sendfile on;
-	tcp_nopush on;
-	types_hash_max_size 2048;
-	# server_tokens off;
-
-	# server_names_hash_bucket_size 64;
-	# server_name_in_redirect off;
-
-	include /etc/nginx/mime.types;
-	default_type application/octet-stream;
-
-	##
-	# SSL Settings
-	##
-
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
-	ssl_prefer_server_ciphers on;
-
-	##
-	# Logging Settings
-	##
-
-	access_log /var/log/nginx/access.log;
-	error_log /var/log/nginx/error.log;
-
-	##
-	# Gzip Settings
-	##
-
-	gzip on;
-
-	# gzip_vary on;
-	# gzip_proxied any;
-	# gzip_comp_level 6;
-	# gzip_buffers 16 8k;
-	# gzip_http_version 1.1;
-	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
-
-	##
-	# Virtual Host Configs
-	##
-
-	include /etc/nginx/conf.d/*.conf;
-	include /etc/nginx/sites-enabled/*;
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
+  include /etc/nginx/mime.types;
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
 }
-
-
-

--- a/tests/unit/test_nginx.py
+++ b/tests/unit/test_nginx.py
@@ -17,7 +17,7 @@ class TestNginxConfigurer(unittest.TestCase):
     @patch("os.remove")
     @patch("shutil.copy")
     def test__configure_daemon(self, mock_copy, mock_remove):
-        context = {"main": {"foo": "bar"}, "events": {"baz": "test"}}
+        context = {"main": {"foo": "bar"}, "events": {"baz": "test"}, "http": {"plugh": "xyzzy"}}
 
         with open("./templates/nginx.conf") as f:
             input = f.read()
@@ -28,7 +28,7 @@ class TestNginxConfigurer(unittest.TestCase):
             self.nginx.configure_daemon(context)
 
             (rendered_content,) = mock_write.return_value.write.call_args[0]
-            expected_content = ("foo bar;", "baz test;")
+            expected_content = ("foo bar;", "baz test;", "plugh xyzzy;")
 
             for content in expected_content:
                 assert content in rendered_content


### PR DESCRIPTION
## Summary
This pull request adds the option to handle Nginx configuration contexts via a helper class.

### Changes
- Adds the `ConfigurationContext` class to abstract the nginx configuration context.
- Adds the `nginx-http-config` to handle the `http` context configuration.
- Sets the Nginx defaults (extracted from the base template) in the code.
- Refactors the `nginx.conf` template.

### Related Issues
[LP#1893681](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1893681)
