### PR TITLE
Fix failure in hacluster integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributor Guide
 
-This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contibutions
+This Juju charm is open source ([Apache License 2.0](./LICENSE)) and we actively seek any community contributions
 for code, suggestions and documentation.
 This page details a few notes, workflows and suggestions for how to make contributions most effective and help us
 all build a better charm - please give them a read before working on any contributions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-li
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
 interface_hacluster @ git+https://github.com/openstack/charm-interface-hacluster
-

--- a/src/charm.py
+++ b/src/charm.py
@@ -112,7 +112,6 @@ class CharmKubeApiLoadBalancer(ops.CharmBase):
         if self.hacluster.is_ready:
             status.add(MaintenanceStatus("Configuring HACluster"))
             self.hacluster.update_vips()
-            self.hacluster.update_dns()
             self.hacluster.configure_hacluster()
             self.hacluster.add_service("nginx", "nginx")
         else:

--- a/src/hacluster.py
+++ b/src/hacluster.py
@@ -131,10 +131,6 @@ class HACluster(Object):
         if name in desired_services:
             del desired_services[name]
 
-    def update_dns(self):
-        """Remove the existing DNS records associated with the unit."""
-        self.interface.remove_dnsha(self._unit_name, "public")
-
     def update_vips(self):
         """Update the Virtual IP addresses for the HACluster relation."""
         original_vips = self.state.vips

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,7 +42,6 @@ class TestCharm(unittest.TestCase):
             mock_hacluster.is_ready = True
             self.charm._configure_hacluster()
             mock_hacluster.update_vips.assert_called_once()
-            mock_hacluster.update_dns.assert_called_once()
             mock_hacluster.configure_hacluster.assert_called_once()
             mock_hacluster.add_service.assert_called_once_with("nginx", "nginx")
 

--- a/tests/unit/test_hacluster.py
+++ b/tests/unit/test_hacluster.py
@@ -93,17 +93,3 @@ class TestHACluster(unittest.TestCase):
             cluster.update_vips()
             cluster.configure_hacluster()
             mock_interface.remove_vip.assert_called_once_with(cluster._unit_name, "10.0.0.1")
-
-    def test_update_dns(self):
-        self.harness.update_config(
-            {
-                "ha-cluster-dns": "my-service.example.com",
-            }
-        )
-        cluster = self.cluster
-        with patch.object(cluster, "interface", autospec=True) as mock_interface:
-            with patch.object(cluster.charm.model, "get_binding", autospec=True) as mock_binding:
-                mock_binding.return_value.network.ingress_address = "127.0.0.1"
-                cluster.configure_hacluster()
-                cluster.update_dns()
-                mock_interface.remove_dnsha.assert_called_once_with(cluster._unit_name, "public")


### PR DESCRIPTION
As seen in https://bugs.launchpad.net/bugs/2038348

The `remove_dnsha` method is broken. Don't use it.

This isn't a complete fix, but it does restore feature parity with the old reactive charm.

Most of the time this should be fine. If `ha-cluster-dns` changes, then the charm calls `add_dnsha` which overrides the previous record. The only case where we would want to call `remove_dnsha` is if the `ha-cluster-dns` value changes to `""`, in which case we would want to clear the record that had been set previously.