### PR TITLE
Pin libraries for main, adjust testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ toml
 loadbalancer-interface
 pydantic==1.*
 cosl == 0.0.5
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
-ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
-interface_hacluster @ git+https://github.com/openstack/charm-interface-hacluster
+charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@main
+charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
+ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@main#subdirectory=ops
+interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@main

--- a/src/charm.py
+++ b/src/charm.py
@@ -224,6 +224,7 @@ class CharmKubeApiLoadBalancer(ops.CharmBase):
         )
         return result.strip()
 
+    @status.on_error(status.WaitingStatus("Waiting to restart Nginx"))
     def _install_load_balancer(self):
         """Install and configure the load balancer."""
         status.add(MaintenanceStatus("Installing Load Balancer"))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,6 +20,7 @@ class TestCharm(unittest.TestCase):
         self.harness = ops.testing.Harness(CharmKubeApiLoadBalancer)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.disable_hooks()
         self.charm = self.harness.charm
         self.mock_nginx = mock_nginx
 

--- a/tests/unit/test_hacluster.py
+++ b/tests/unit/test_hacluster.py
@@ -12,6 +12,7 @@ class TestHACluster(unittest.TestCase):
         self.harness = Harness(CharmKubeApiLoadBalancer)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.disable_hooks()
         self.cluster = self.harness.charm.hacluster
 
     def test_add_service(self):


### PR DESCRIPTION
Fix for [LP#2064130](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2064130)

Adjustments were made to the reconciler library such that uncaught Excptions wouldn't block the charm, but instead would error.  Pinning these libraries to their release branches (1.30) requires that expected Errors be caught and handled appropriately.

one such exception shows up regularly with kubeapi-loadbalancer:
```
2024-04-27 14:26:56 ERROR unit.kubeapi-load-balancer/1.juju-log server.go:325 Uncaught exception while in charm code:
Traceback (most recent call last):
  File "./src/charm.py", line 415, in <module>
    ops.main(CharmKubeApiLoadBalancer)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/main.py", line 555, in __call__
    return main(charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/main.py", line 544, in main
    manager.run()
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/main.py", line 520, in run
    self._emit()
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/main.py", line 509, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/main.py", line 143, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/framework.py", line 352, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/framework.py", line 851, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/ops/framework.py", line 941, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/venv/charms/reconciler.py", line 35, in reconcile
    self.reconcile_function(event)
  File "./src/charm.py", line 330, in _reconcile
    self._install_load_balancer()
  File "./src/charm.py", line 245, in _install_load_balancer
    self._restart_nginx()
  File "./src/charm.py", line 359, in _restart_nginx
    service_restart(NGINX_SERVICE)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/lib/charms/operator_libs_linux/v1/systemd.py", line 174, in service_restart
    return _systemctl("restart", service_name)
  File "/var/lib/juju/agents/unit-kubeapi-load-balancer-1/charm/lib/charms/operator_libs_linux/v1/systemd.py", line 125, in _systemctl
    raise SystemdError(
charms.operator_libs_linux.v1.systemd.SystemdError: Could not restart nginx: systemd output: Job for nginx.service canceled.
```