### PR TITLE
Pin setuptools used for noble and jammy

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -72,6 +72,8 @@ bases:
       architectures: ["s390x"]
 parts:
   charm:
+    plugin: charm
+    source: .
     build-packages: [git]
     prime:
       - templates/**

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ops == 2.16.0
 pydantic == 1.10.18
 tenacity == 9.0.0
 toml == 0.10.2
+setuptools==79.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -62,10 +62,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
-    juju
     pytest-operator
-    -r {tox_root}/requirements.txt
+    pyyaml
 commands =
     pytest -v \
            -s \


### PR DESCRIPTION
* pins setuptools used by python 3.10 and 3.12 
* overrides charmcraft 2.x's default of `setuptools-59.6.0`

Similar to:
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/385
* https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/191
* https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/40
* https://github.com/charmed-kubernetes/charm-calico/pull/119
* https://github.com/charmed-kubernetes/charm-kube-ovn/pull/60