### PR TITLE
fix: use tarfile filter='data' for safe extraction (B202)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -302,7 +302,7 @@ class CharmKubeApiLoadBalancer(ops.CharmBase):
         install_path = Path("/opt", EXPORTER)
         install_path.mkdir(parents=True, exist_ok=True)
         with tarfile.open(resource_path) as tar:
-            tar.extractall(install_path)
+            tar.extractall(install_path, filter="data")
 
         path = Path(f"/etc/systemd/system/{EXPORTER}.service")
         if not path.exists():


### PR DESCRIPTION
## Summary

Use `tarfile.extractall(filter="data")` to guard against path traversal in tar entries, replacing the previous `# nosec B202` annotation.

The `filter="data"` option (Python 3.12+) strips unsafe tar metadata — absolute paths, symlinks to outside destinations, setuid/setgid bits — while still extracting file contents normally. This is the recommended fix for bandit B202.

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.